### PR TITLE
Refactor dialog to have a open close state instead of a farwarded ref

### DIFF
--- a/components/Dialog.tsx
+++ b/components/Dialog.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, type ReactElement } from "react";
+import { type ReactElement } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -7,40 +7,44 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  DialogTrigger,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 
-const RenameCompanyDialog = forwardRef<HTMLButtonElement, {}>(
-  (_, ref): ReactElement => {
-    return (
-      <Dialog>
-        <DialogTrigger asChild>
-          <Button className="invisible" ref={ref} />
-        </DialogTrigger>
-        <DialogContent className="sm:max-w-[425px]">
-          <DialogHeader>
-            <DialogTitle>Rename Company</DialogTitle>
-            <DialogDescription>
-              Make changes to your profile here. Click save when youre done.Make
-              changes to your profile here. Click save when youre done.
-            </DialogDescription>
-          </DialogHeader>
-          <Input id="name" className="w-full outline outline-indigo-500" />
-          <DialogFooter>
-            <Button className="bg-transparent text-black" variant="outline">
-              Cancel
-            </Button>
-            <Button type="submit" className="bg-indigo-500 hover:bg-indigo-500">
-              Save
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    );
-  }
-);
+type RenameCompanyDialogPropsType = {
+  isOpen: boolean;
+  onClose: () => void;
+};
 
-RenameCompanyDialog.displayName = "RenameCompanyDialog"; // Add displayName since this is usding farwardRedf
+const RenameCompanyDialog = ({
+  isOpen,
+  onClose,
+}: RenameCompanyDialogPropsType): ReactElement => {
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle>Rename Company</DialogTitle>
+          <DialogDescription>
+            Make changes to your profile here. Click save when youre done.Make
+            changes to your profile here. Click save when youre done.
+          </DialogDescription>
+        </DialogHeader>
+        <Input id="name" className="w-full outline outline-indigo-500" />
+        <DialogFooter>
+          <Button
+            onClick={onClose}
+            className="bg-transparent text-black"
+            variant="outline"
+          >
+            Cancel
+          </Button>
+          <Button type="submit" className="bg-indigo-500 hover:bg-indigo-500">
+            Save
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
 
 export default RenameCompanyDialog;

--- a/components/Table.tsx
+++ b/components/Table.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, type ReactElement } from "react";
+import { useState, type ReactElement } from "react";
 import {
   Table,
   TableBody,
@@ -22,13 +22,9 @@ import tableConfig from "@/lib/tableConfig";
 import RenameCompanyDialog from "./Dialog";
 
 export default function EntitiesTable(): ReactElement {
-  // unfortunatly the dialog in shadcn doesn't take any state to open or close
-  //and has to be toggled using a DialogTrigger component and DialogTrigger must be
-  // child of Dialog. So one way was to wrap the whole table in Dialog component so that I
-  // cn use DialogTrigger in Table but it is not a cleaner solution. So I created a ref
-  // which I farwarded it to Dialog and attached it on the DialogTrigger and whenever
-  // row in table is clicked I'm manually clicking the DialogTrigger using ref
-  const dialogTriggerRef = useRef<HTMLButtonElement>(null);
+  // I was actually wrong, dialog actually does take a prop to open and close
+  const [isOpen, setIsOpen] = useState(false);
+  const onClose = () => setIsOpen(false);
 
   return (
     <>
@@ -76,7 +72,7 @@ export default function EntitiesTable(): ReactElement {
                   // like TanStack table or MUI grid so that it passes me the data of the
                   // row clicked i.e id so that I can make a put/patch request to API with
                   // theh upodated company name and company id
-                  onClick={() => dialogTriggerRef.current?.click()}
+                  onClick={() => setIsOpen(true)}
                 >
                   <TableCell className="font-medium">
                     <small className="text-sm font-medium leading-none">
@@ -115,7 +111,7 @@ export default function EntitiesTable(): ReactElement {
           </Table>
         </CardContent>
       </Card>
-      <RenameCompanyDialog ref={dialogTriggerRef} />
+      <RenameCompanyDialog isOpen={isOpen} onClose={onClose} />
     </>
   );
 }


### PR DESCRIPTION
Dialog actually does take a open/close prop so I Refactored to have an open/close state instead of a forwarded ref